### PR TITLE
Added missing dependencies for Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,24 @@
        <artifactId>tsugi-util</artifactId>
        <version>0.1-SNAPSHOT</version>
     </dependency>
+	
+	<dependency>
+	    <groupId>com.fasterxml.jackson.core</groupId>
+	    <artifactId>jackson-core</artifactId>
+	    <version>2.7.3</version>
+	</dependency>
+
+	<dependency>
+	    <groupId>com.fasterxml.jackson.core</groupId>
+	    <artifactId>jackson-databind</artifactId>
+	    <version>2.7.3</version>
+	</dependency>
+
+	<dependency>
+	    <groupId>com.fasterxml.jackson.core</groupId>
+	    <artifactId>jackson-annotations</artifactId>
+	    <version>2.7.3</version>
+	</dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
I needed to add these Jackson dependencies to fix ClassNotFound once LTI plugin setup. 
